### PR TITLE
Make contents centering

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -12,7 +12,10 @@
     "lint:style": "deno run -A npm:stylelint@15.10.2 ./**/*.css"
   },
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "types": [
+      "lume/types.ts"
+    ],
+    "jsx": "precompile",
     "jsxImportSource": "npm:preact@10.21.0"
   },
   "lint": {

--- a/site/_includes/article.tsx
+++ b/site/_includes/article.tsx
@@ -5,10 +5,6 @@ import SuggestButton from "./components/suggestButton.tsx";
 
 export const layout = "base.tsx";
 
-const contentWidth = {
-  width: "max(80%, min(100%, 1024px))",
-};
-
 type PageData = Data & {
   topics?: string[];
 };
@@ -16,22 +12,22 @@ type PageData = Data & {
 export default ({ title, children, topics, page }: PageData) => (
   <>
     <a href={joinUrl("/")}>&lt; Return to index</a>
-    <div className="flex justify-center flex-col gap-y-4">
-      <h1 className="text-3xl">
-        {title}
-      </h1>
-      <div className="flex gap-2">
-        {(topics ?? []).map((topic) => (
-          <TopicButton
-            topic={topic}
-            key={topic}
-          />
-        ))}
+    <article className="overflow-ellipsis">
+      <div className="flex justify-center flex-col gap-y-4">
+        <h1 className="text-4xl text-center">
+          {title}
+        </h1>
+        <div className="flex gap-2">
+          {(topics ?? []).map((topic) => (
+            <TopicButton
+              topic={topic}
+              key={topic}
+            />
+          ))}
+        </div>
       </div>
-      <main className="overflow-ellipsis" style={contentWidth}>
-        <article className="leading-loose article">{children}</article>
-      </main>
+      <section className="leading-loose article">{children}</section>
       <SuggestButton path={page?.src.entry?.path ?? ""} />
-    </div>
+    </article>
   </>
 );

--- a/site/_includes/base.tsx
+++ b/site/_includes/base.tsx
@@ -1,6 +1,10 @@
 import type { Data } from "lume/core/file.ts";
 import { SearchBox } from "./searchBox.tsx";
 
+const contentWidth = {
+  maxWidth: "800px",
+};
+
 export default ({ title, children, blogTitle }: Data) => (
   <>
     <html lang="ja">
@@ -32,8 +36,12 @@ export default ({ title, children, blogTitle }: Data) => (
         />
       </head>
       <body className="p-10">
-        <SearchBox />
-        {children}
+        <header></header>
+        <main class="mx-auto my-0" style={contentWidth}>
+          <SearchBox />
+          {children}
+        </main>
+        <footer></footer>
       </body>
     </html>
   </>


### PR DESCRIPTION
This PR provide style that `main` contents place to center position.

- refactor: delete searchbox
- refactor: apply centering size


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced JSX compilation settings for improved performance.
  - Updated page layout and styling for articles, including replacing main content containers and adjusting visual presentation.
  - Introduced new styling and structural layout adjustments in base template, including content width limitations and new header and footer elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->