### PR TITLE
feat: use container query instead

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -79,7 +79,7 @@ import HeaderLink from "./HeaderLink.astro";
     display: flex;
   }
 
-  @media (width <= 720px) {
+  @container root (width <= 720px) {
     .social-links {
       display: none;
     }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -40,6 +40,7 @@ import HeaderLink from "./HeaderLink.astro";
     margin: 0;
     background: white;
     box-shadow: 0 2px 8px rgb(var(--black), 5%);
+    container-type: inline-size;
   }
 
   h2 {
@@ -79,7 +80,7 @@ import HeaderLink from "./HeaderLink.astro";
     display: flex;
   }
 
-  @container root (width <= 720px) {
+  @container (width <= calc(720px - 2em)) {
     .social-links {
       display: none;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       list-style-type: none;
     }
 
-    @media (width <= 720px) {
+    @container root (width <= 720px) {
       ul {
         gap: 0.5em;
       }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,25 +8,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     @view-transition {
       navigation: auto;
     }
-
-    main {
-      width: 960px;
-    }
-
-    ul {
-      display: flex;
-      flex-flow: column wrap;
-      gap: 2rem;
-      padding: 0;
-      margin: 0;
-      list-style-type: none;
-    }
-
-    @container root (width <= 720px) {
-      ul {
-        gap: 0.5em;
-      }
-    }
   </style>
   <section>
     <ul>
@@ -34,3 +15,14 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     </ul>
   </section>
 </BaseLayout>
+
+<style>
+  ul {
+    display: flex;
+    flex-flow: column wrap;
+    gap: 2rem;
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+  }
+</style>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -8,25 +8,6 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
     @view-transition {
       navigation: auto;
     }
-
-    main {
-      width: 960px;
-    }
-
-    ul {
-      display: flex;
-      flex-flow: column wrap;
-      gap: 2rem;
-      padding: 0;
-      margin: 0;
-      list-style-type: none;
-    }
-
-    @container root (width <= 720px) {
-      ul {
-        gap: 0.5em;
-      }
-    }
   </style>
   <section>
     <ul>
@@ -34,3 +15,14 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
     </ul>
   </section>
 </BaseLayout>
+
+<style>
+  ul {
+    display: flex;
+    flex-flow: column wrap;
+    gap: 2rem;
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+  }
+</style>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -22,7 +22,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
       list-style-type: none;
     }
 
-    @media (width <= 720px) {
+    @container root (width <= 720px) {
       ul {
         gap: 0.5em;
       }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,6 +16,7 @@
     rgb(var(--gray), 33%), 0 16px 32px rgb(var(--gray), 33%);
 
   view-transition-name: none;
+  container: root / inline-size;
 }
 
 body {
@@ -131,7 +132,7 @@ hr {
   border-top: 1px solid rgb(var(--gray-light));
 }
 
-@media (width <= 720px) {
+@container root (width <= 720px) {
   body {
     font-size: 18px;
   }


### PR DESCRIPTION
close #738

- **refactor: use container query instead**
- **refactor: use self component size**
- **refactor: move into component style**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated responsive styles to use container queries instead of media queries, providing more adaptive layouts based on container size rather than viewport size.
  - Refined list (`ul`) styles for improved consistency and maintainability.
  - Removed certain media-query-based gap and width adjustments for a cleaner, container-driven approach to responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->