### PR TITLE
feat: add an articles about daikon.vim

### DIFF
--- a/src/content/post/2025-08-22-daikon-vim-2.md
+++ b/src/content/post/2025-08-22-daikon-vim-2.md
@@ -14,7 +14,7 @@ type: tech
 
 ### アイコンのpngをつくる
 
-VimConfのチケットを書いたいが、去年pngに変換するのが大変だったと聞いた記憶があったのでpngを用意する。
+VimConfのチケットを買いたいが、去年pngに変換するのが大変だったと聞いた記憶があったのでpngを用意する。
 
 ```console
 $ magick convert Omochice.jpg Omochice.png

--- a/src/content/post/2025-08-22-daikon-vim-2.md
+++ b/src/content/post/2025-08-22-daikon-vim-2.md
@@ -1,0 +1,38 @@
+---
+title: "daikon.vim #2に参加した"
+date: 2025-08-22
+topics: ["vim", "#daikonvim"]
+excerpt: ''
+type: tech
+---
+
+[daikon.vim #2](https://daikonvim.connpass.com/event/363680/)に参加した。
+
+中身はもくもく会である。
+
+## やったこと
+
+### アイコンのpngをつくる
+
+VimConfのチケットを書いたいが、去年pngに変換するのが大変だったと聞いた記憶があったのでpngを用意する。
+
+```console
+$ magick convert Omochice.jpg Omochice.png
+```
+
+### augroupから`#`を消す
+
+[Vimのaugroup名に `#` は使ってはいけない](https://zenn.dev/vim_jp/articles/20250818_ekiden_augroup_hash)
+
+dotfilesからは消したけどプラグインに残存してるので消す。
+
+- [refactor: stop to use `#` in augroup name by Omochice · Pull Request #14 · Omochice/yank-remote-url.vim](https://github.com/Omochice/yank-remote-url.vim/pull/14)
+- [refactor: stop to use `#` in augroup name by Omochice · Pull Request #123 · Omochice/tataku-emitter-nvim_floatwin](https://github.com/Omochice/tataku-emitter-nvim_floatwin/pull/123)
+
+### prettierの実行時フラグを消す
+
+nodeの[22.18.0](https://nodejs.org/en/blog/release/v22.18.0)で`--experimental-strip-types`のフラグなしでtypescriptが動くようになったので、フラグを外す。
+
+[refactor: stop to use `experimental-strip-types` by Omochice · Pull Request #1063 · Omochice/heart-of-crown-randomizer](https://github.com/Omochice/heart-of-crown-randomizer/pull/1063#event-19286116187)
+
+あとはお話しをしたり。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new blog post: “daikon.vim #2に参加した.”
  * Covers event highlights and three practical takeaways:
    - Creating a PNG icon via ImageMagick.
    - Removing “#” from Vim augroup names with references to related changes.
    - Dropping Prettier’s experimental strip-types flag aligned with recent Node.js updates.
  * Includes external links to event info and related pull requests.
  * Provides YAML front matter (title, date, topics, excerpt, type) for improved categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->