### PR TITLE
refactor: stop to use `experimental-strip-types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf dist",
     "dev": "astro dev",
     "fmt": "npm-run-all fmt:*",
-    "fmt:astro": "NODE_OPTIONS='--experimental-strip-types' prettier --write **/*.astro",
+    "fmt:astro": "prettier --write **/*.astro",
     "fmt:biome": "npm-run-all fmt:biome:*",
     "fmt:biome:check": "biome check --write",
     "fmt:biome:format": "biome format --write",


### PR DESCRIPTION
node 22.18.0 sets it as default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Astro file formatting script to use a standard configuration, removing an experimental runtime flag.
  * Developer tooling cleanup only; no impact on application behavior or performance.

* **No User-Facing Changes**
  * This update does not alter features, UI, or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->