### PR TITLE
feat: use `f90` for highlighting

### DIFF
--- a/src/content/post/2021-01-23-canny-fortran.md
+++ b/src/content/post/2021-01-23-canny-fortran.md
@@ -21,7 +21,7 @@ github で `canny edge detection langages:fortran` で調べたがヒットは�
 
 エッジの方向検出がいまいち納得できてない。
 
-```fortran
+```f90
 if ((way >= -1*PI/8 .and. way < PI/8) .or. (way < -7*PI/8 .or. way >= 7*PI/8)) then
   edges = edge_magnitudes(h - 1:h + 1, w)
 else if ((way >= PI/8 .and. way < 3*PI/8) .or. (way >= -7*PI/8 .and. way < -5*PI/8)) then

--- a/src/content/post/2021-01-24-bilateral-fortran.md
+++ b/src/content/post/2021-01-24-bilateral-fortran.md
@@ -10,7 +10,7 @@ type: tech
 
 canny に続いて birateral filter を作った。
 
-```fortran
+```f90
   subroutine bilateral(img, output, sigma)
   !!! apply bilateral filter
   !!!
@@ -60,7 +60,7 @@ canny に続いて birateral filter を作った。
 
 注目画素(今回は 5\*5)なので `3~width-2` までに対して周辺 25 画素を。
 
-```fortran
+```f90
 window = img(h - 2:h + 2, w - 2:w + 2)
 ```
 
@@ -70,7 +70,7 @@ window = img(h - 2:h + 2, w - 2:w + 2)
 
 毎画素ごとにガウス分布を求めるのは冗長みたいなので予め 0~255 の範囲のガウス分布を求めておく。
 
-```fortran
+```f90
 gaussian_dist = (/(exp(-(real(i)/255)**2/(2*sigma**2)), i=0, 255)/)
 ```
 

--- a/src/content/post/2021-01-29-fortran-func-subroutine.md
+++ b/src/content/post/2021-01-29-fortran-func-subroutine.md
@@ -10,7 +10,7 @@ type: tech
 
 Python で言うところの `list.append()` みたいな感じで引数自身が返り値の性質を持つときは subroutine で書く方が多分それっぽくなる。
 
-```fortran
+```f90
 subroutine foo(a)
   implicit none
   integer, intent(inout) :: a
@@ -24,7 +24,7 @@ end subroutine foo
 
 function だとこんな感じで書く。
 
-```fortran
+```f90
 pure function foo(n) result(r)
   implicit none
   integer, intent(in) :: n(:)

--- a/src/content/post/2021-02-01-fortran-imageio.md
+++ b/src/content/post/2021-02-01-fortran-imageio.md
@@ -47,7 +47,7 @@ P3
 
 読み取って 3 次元配列を返す function を fortran で書く。
 
-```fortran
+```f90
 function load_pnm(filename) result(img_array)
   !!! load_pnm
   !!!
@@ -119,7 +119,7 @@ Python なら `raise FormatError` とかするんだけど fortran でエラー�
 
 入力時と逆のことをやる。
 
-```fortran
+```f90
 subroutine save_pnm(img_array, maximum_value, filename)
   !!! Save array as pnm image.
   !!\!
@@ -179,7 +179,7 @@ Python なら `" ".join(map(str, (width, height)))` とかで書くんだけど 
 fortran には matplotlib みたいに簡単に可視化できるものがなさそうなのでおとなしく `display` を使う。
 `display` がない環境はそもそもに `convert` がないはずなのでここまで来る前にエラーに遭うはず。
 
-```fortran
+```f90
 subroutine display_img(img, maximum_value)
   !!! Display array img.
   !!! save array as pnm image named "output.pnm" then show via imagemagick.
@@ -206,7 +206,7 @@ end subroutine display_img
 
 これを `gfortran pnm_tools.f90 -c` で `.o` を作成したら次のテストプログラムが動く。
 
-```fortran
+```f90
 program test_load_pnm
   use pnm_tools
   implicit none

--- a/src/content/post/2021-02-13-fortran-gradation.md
+++ b/src/content/post/2021-02-13-fortran-gradation.md
@@ -18,7 +18,7 @@ $$
 
 fortran の pure function で書くと次のようになる。
 
-```fortran
+```f90
 
 pure function linear_translation(img, maximum) result(translated)
   implicit none
@@ -46,7 +46,7 @@ fortran だとわざわざループして lut を適用しなくても `translat
 
 結果以下のようになった。
 
-```fortran
+```f90
 pure function linear_translation(img, maximum_value, low_threshold, high_threshold) result(translated)
   implicit none
   integer, intent(in) :: img(:, :, :)


### PR DESCRIPTION
`fortran` is not supported for highlighting.

Use `f90` instead.

ref: https://shiki.style/languages
