### PR TITLE
feat: show link to original source

### DIFF
--- a/src/components/LinkToGitHub.astro
+++ b/src/components/LinkToGitHub.astro
@@ -1,0 +1,36 @@
+---
+import { joinURL } from "ufo";
+import { DEFAULT_BRANCH, REPOSITORY } from "../consts";
+
+type Props = { path: string };
+
+const { path } = Astro.props;
+
+const href = joinURL(REPOSITORY.href, "blob", DEFAULT_BRANCH, path);
+---
+
+<div class="github-link">
+  <a
+    {href}
+    rel="noopener noreferrer"
+  >
+    View source on GitHub
+  </a>
+</div>
+
+<style>
+  .github-link {
+    text-align: center;
+  }
+
+  .github-link a {
+    font-size: 0.9em;
+    color: rgb(var(--gray));
+    text-decoration: none;
+  }
+
+  .github-link a:hover {
+    color: rgb(var(--gray-dark));
+    text-decoration: underline;
+  }
+</style>

--- a/src/components/LinkToGitHub.astro
+++ b/src/components/LinkToGitHub.astro
@@ -10,12 +10,7 @@ const href = joinURL(REPOSITORY.href, "blob", DEFAULT_BRANCH, path);
 ---
 
 <div class="github-link">
-  <a
-    href={href}
-    rel="noopener noreferrer"
-  >
-    View source on GitHub
-  </a>
+  <a href={href}> View source on GitHub </a>
 </div>
 
 <style>

--- a/src/components/LinkToGitHub.astro
+++ b/src/components/LinkToGitHub.astro
@@ -11,7 +11,7 @@ const href = joinURL(REPOSITORY.href, "blob", DEFAULT_BRANCH, path);
 
 <div class="github-link">
   <a
-    {href}
+    href={href}
     rel="noopener noreferrer"
   >
     View source on GitHub

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,5 @@
 export const SITE_TITLE = "$ Omochice 2>&1";
 export const SITE_DESCRIPTION = "Omochice's stdout and stderr";
 export const NAME = "Omochice";
+export const REPOSITORY = new URL("https://github.com/Omochice/blog");
+export const DEFAULT_BRANCH = "main";

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
+import LinkToGitHub from "../../components/LinkToGitHub.astro";
 import BlogPost from "../../layouts/BlogPost.astro";
 
 export async function getStaticPaths() {
@@ -20,4 +21,12 @@ const { Content } = await post.render();
   slug={`transition-${post.slug}`}
 >
   <Content />
+  {
+    post.filePath != null && (
+      <>
+        <hr />
+        <LinkToGitHub path={post.filePath} />
+      </>
+    )
+  }
 </BlogPost>


### PR DESCRIPTION
ssia

- **feat: add component to link original source**
- **feat: show link to original source**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “View source on GitHub” link to blog posts, shown when the source file is available. The link opens the corresponding file on the repository’s default branch and appears after post content with a subtle divider.

* **Style**
  * The source link is centered and styled with muted colors and a hover underline for unobtrusive visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->