### PR TITLE
refactor: use zod directly instead of deprecated astro:content re-export

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "textlint-rule-no-dead-link": "6.2.1",
     "typescript": "6.0.3",
     "ufo": "1.6.3",
-    "vitest": "4.1.4"
+    "vitest": "4.1.4",
+    "zod": "4.3.6"
   },
   "packageManager": "pnpm@10.33.0",
   "devEngines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@types/node@24.12.2)(vite@7.3.2(@types/node@24.12.2)(lightningcss@1.32.0)(yaml@2.8.3))
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
 
 packages:
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
+import { z } from "zod";
 
 const post = defineCollection({
   loader: glob({ base: "./src/content/post", pattern: "**/*.md" }),


### PR DESCRIPTION
## Summary

Import `z` directly from `zod` in the content collection config, replacing the `z` re-export from `astro:content` that Astro v6 deprecated.

## Details

Astro v6.1.8 marks the `z` re-export from `astro:content` as deprecated (ts(6385) hints) and recommends importing from `zod` directly. The deprecation does not break the build, but leaving it unaddressed carries a removal risk in a future Astro release and pollutes `astro check` output with ten hints on a single file.

`zod` is added as a pinned devDependency at `4.3.6` to match the range (`^4.3.6`) Astro itself declares, which keeps a single resolved `zod` instance in the graph and avoids subtle instance-identity problems between the schema and whatever version Astro's internals use.

## Confirmation

- `pnpm check:astro` → 0 errors, 0 warnings, 0 hints
- `pnpm build` → 89 pages built successfully

## Limitation

No known limitations. The change is scoped to `src/content.config.ts` plus the dependency manifests; no runtime behavior or generated output changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a validation library to development dependencies.
  * Updated project configuration imports to utilize the new library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->