### PR TITLE
feat: add an article for gh-infra

### DIFF
--- a/src/content/post/2026-05-05-256dddba.md
+++ b/src/content/post/2026-05-05-256dddba.md
@@ -1,0 +1,79 @@
+---
+title: "gh-infraを試したメモ"
+date: 2026-05-05
+description: ""
+type: tech
+---
+
+GWなので色々ためしてみている。
+
+## gh-infra
+
+[babarot/gh-infra: Declarative GitHub infrastructure management via YAML](https://github.com/babarot/gh-infra)
+
+Terraformではない方法でRepositoryの設定を管理できるみたい。
+
+以前にTerraformのGitHub Providerを試したときは、Copilot Reviewが指定できなくて断念したのでこっちでできるのなら使いたいなという動機である。
+
+[GitHubのRepositoryの設定をOpenTofuで管理してみようとした](https://omochice.github.io/blog/posts/2025-06-01-manage-github-repository-by-tofu/)
+
+以下、`v0.13.0`時点の情報を元に書く。
+
+## 既存の設定の読み込み
+
+<https://github.com/babarot/gh-infra/tree/v0.13.0#quick-start>に書いてある通り。
+
+```console
+gh infra import babarot/my-project > my-project.yaml
+```
+
+上記でリポジトリの設定を書き出せる。
+
+centralなリポジトリで管理しないのであれば、`.github/gh-infra.yaml`とかに置くのがよいのだろうか？
+
+## CIで変更検知
+
+`administration: read`が必要みたい。
+
+この権限はCIのJob Tokenでは付与できないので、GitHub Appを発行しないとだめそう。
+
+ローカルであれば、多くの場合この権限があるはずなので以下で確認できる。
+
+```console
+gh infra plan --ci path/to/config.yaml
+```
+
+差分があると以下のように出力される。
+
+```console
+$ gh infra plan --ci .github/gh-infra.yaml
+Reading desired state from ~/ghq/github.com/Omochice/ddc-source-cc_command/.github/gh-infra.yaml ...
+Fetching current state from GitHub API ...
+
+  ✓ Omochice/ddc-source-cc_command  planned desired changes
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Resource actions are indicated with the following symbols:
+  ~ update
+
+  # Omochice/ddc-source-cc_command will be updated
+  ~ Omochice/ddc-source-cc_command
+      ~ actions
+          ~ sha_pinning_required  true → false
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Plan: 0 to create, 1 to update, 0 to destroy
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+To apply, run: gh infra apply
+```
+
+## skills
+
+現代のツールらしく、Coding Agent向けのskillsも同梱されている。
+
+<https://github.com/babarot/gh-infra/tree/v0.13.0/skills>

--- a/src/content/post/2026-05-05-256dddba.md
+++ b/src/content/post/2026-05-05-256dddba.md
@@ -15,7 +15,7 @@ Terraformではない方法でRepositoryの設定を管理できるみたい。
 
 以前にTerraformのGitHub Providerを試したときは、Copilot Reviewが指定できなくて断念したのでこっちでできるのなら使いたいなという動機である。
 
-[GitHubのRepositoryの設定をOpenTofuで管理してみようとした](https://omochice.github.io/blog/posts/2025-06-01-manage-github-repository-by-tofu/)
+[GitHubのRepositoryの設定をOpenTofuで管理してみようとした](./2025-06-01-manage-github-repository-by-tofu/)
 
 以下、`v0.13.0`時点の情報を元に書く。
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new blog post describing declarative management of GitHub repository settings with gh-infra, including how to export existing settings and storage options.
  * Documents CI change-detection requirements (administration: read) and recommends using a GitHub App for CI access.
  * Provides example commands, sample planned-change output, and notes on bundled skills for coding agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->