### PR TITLE
feat: hold future-dated posts until their publish date

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   schedule:
+    - cron: "5 15 * * *"
     - cron: "30 9 * * *"
 
 jobs:

--- a/src/components/PostLists.astro
+++ b/src/components/PostLists.astro
@@ -1,14 +1,14 @@
 ---
-import { getCollection } from "astro:content";
 import { joinURL } from "ufo";
 import FormattedDate from "../components/FormattedDate.astro";
+import { getPosts } from "../lib/get-posts";
 import { budouxfy } from "../lib/parse-with-budoux";
 
 interface Props {
   size?: number;
 }
 
-const posts = (await getCollection("post"))
+const posts = (await getPosts())
   .filter((post) => post.data.type !== "poem")
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, Astro.props.size);

--- a/src/lib/get-posts.ts
+++ b/src/lib/get-posts.ts
@@ -1,0 +1,19 @@
+import { getCollection } from "astro:content";
+import { isPublished } from "./is-published";
+
+/**
+ * Get all posts, excluding those scheduled for a future date.
+ *
+ * Future-dated posts are filtered out only in production builds, so that
+ * `astro dev` can still preview a scheduled post before its date arrives.
+ *
+ * @returns The posts that are published as of build time.
+ */
+export const getPosts = async () => {
+  const posts = await getCollection("post");
+  if (!import.meta.env.PROD) {
+    return posts;
+  }
+  const now = new Date();
+  return posts.filter((post) => isPublished(post.data.date, now));
+};

--- a/src/lib/is-published.test.ts
+++ b/src/lib/is-published.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isPublished } from "./is-published";
+
+describe("isPublished", () => {
+  it("should publish a post dated before today (JST)", () => {
+    expect(
+      isPublished(new Date("2026-01-01"), new Date("2026-05-24T03:00:00Z")),
+    ).toBe(true);
+  });
+
+  it("should publish a post dated exactly today (JST)", () => {
+    expect(
+      isPublished(new Date("2026-05-24"), new Date("2026-05-24T03:00:00Z")),
+    ).toBe(true);
+  });
+
+  it("should not publish a post dated in the future (JST)", () => {
+    expect(
+      isPublished(new Date("2026-12-31"), new Date("2026-05-24T03:00:00Z")),
+    ).toBe(false);
+  });
+
+  // The 0:05 JST build runs at 15:05 UTC on the previous UTC day. A naive UTC
+  // comparison would treat the just-arrived JST date as still in the future.
+  describe("at the JST-midnight build (now = 2026-01-01T15:05:00Z = 2026-01-02 00:05 JST)", () => {
+    const now = new Date("2026-01-01T15:05:00Z");
+
+    it("should publish a post dated to the new JST day", () => {
+      expect(isPublished(new Date("2026-01-02"), now)).toBe(true);
+    });
+
+    it("should not publish a post dated the day after", () => {
+      expect(isPublished(new Date("2026-01-03"), now)).toBe(false);
+    });
+  });
+});

--- a/src/lib/is-published.ts
+++ b/src/lib/is-published.ts
@@ -1,0 +1,22 @@
+const jstDateFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Tokyo",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/**
+ * Check whether a post should be published as of the given moment.
+ *
+ * Both dates are reduced to their calendar date in Asia/Tokyo before being
+ * compared, so a post is published once its date has arrived in JST. Comparing
+ * in JST rather than UTC is required because the scheduled build runs at 0:05
+ * JST, which is the previous calendar day in UTC.
+ *
+ * @param postDate The `date` of the post.
+ * @param now The current moment.
+ * @returns Whether the post is published.
+ */
+export const isPublished = (postDate: Date, now: Date): boolean => {
+  return jstDateFormatter.format(postDate) <= jstDateFormatter.format(now);
+};

--- a/src/lib/is-published.ts
+++ b/src/lib/is-published.ts
@@ -6,6 +6,20 @@ const jstDateFormatter = new Intl.DateTimeFormat("en-CA", {
 });
 
 /**
+ * Build a zero-padded `YYYYMMDD` key for a date in Asia/Tokyo.
+ *
+ * Parts are picked by `type` rather than read from `format()` output, so the
+ * key does not depend on the locale's date order or separators, which keeps the
+ * lexicographic comparison correct even where the ICU data differs.
+ */
+const jstDateKey = (date: Date): string => {
+  const parts = jstDateFormatter.formatToParts(date);
+  const pick = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return `${pick("year")}${pick("month")}${pick("day")}`;
+};
+
+/**
  * Check whether a post should be published as of the given moment.
  *
  * Both dates are reduced to their calendar date in Asia/Tokyo before being
@@ -18,5 +32,5 @@ const jstDateFormatter = new Intl.DateTimeFormat("en-CA", {
  * @returns Whether the post is published.
  */
 export const isPublished = (postDate: Date, now: Date): boolean => {
-  return jstDateFormatter.format(postDate) <= jstDateFormatter.format(now);
+  return jstDateKey(postDate) <= jstDateKey(now);
 };

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -1,9 +1,9 @@
-import { getCollection } from "astro:content";
 import { container, text } from "@takumi-rs/helpers";
 import type { APIRoute, GetStaticPaths } from "astro";
 import { loadDefaultJapaneseParser } from "budoux";
 import { ImageResponse } from "takumi-js/response";
 import { SITE_TITLE } from "../../consts";
+import { getPosts } from "../../lib/get-posts";
 import { ogFonts } from "../../lib/og-fonts";
 
 const parser = loadDefaultJapaneseParser();
@@ -16,7 +16,7 @@ const titleStyle = {
 } as const;
 
 export const getStaticPaths = (async () => {
-  const posts = await getCollection("post");
+  const posts = await getPosts();
   return posts.map((post) => ({
     params: { slug: post.id },
     props: { title: post.data.title },

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,11 +1,12 @@
 ---
-import { type CollectionEntry, getCollection, render } from "astro:content";
+import { type CollectionEntry, render } from "astro:content";
 import { joinURL } from "ufo";
 import LinkToGitHub from "../../components/LinkToGitHub.astro";
 import BlogPost from "../../layouts/BlogPost.astro";
+import { getPosts } from "../../lib/get-posts";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("post");
+  const posts = await getPosts();
   return posts.map((post) => ({
     params: { slug: post.id },
     props: post,

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,16 +1,17 @@
-import { getCollection, render } from "astro:content";
+import { render } from "astro:content";
 import rss from "@astrojs/rss";
 import { experimental_AstroContainer } from "astro/container";
 import sanitizeHtml from "sanitize-html";
 import { joinURL } from "ufo";
 import { SITE_DESCRIPTION, SITE_TITLE } from "../consts";
+import { getPosts } from "../lib/get-posts";
 
 type Context = {
   site: string;
 };
 
 export async function GET(context: Context) {
-  const posts = await getCollection("post");
+  const posts = await getPosts();
   const container = await experimental_AstroContainer.create();
   const items = await Promise.all(
     posts


### PR DESCRIPTION
## Summary

Exclude future-dated posts from the production build and release them automatically once their date arrives in JST.

## Details

`getPosts()` wraps `getCollection` and drops future-dated posts in production builds only (dev still shows all).
The comparison uses the Asia/Tokyo date because the added 0:05 JST build runs at 15:05 UTC on the previous UTC day, where a UTC comparison would hide the just-due post.

## Confirmation

- vitest 7 passed; astro check, biome, actionlint clean.
- Built with a temporary future-dated post: absent from page, OG, RSS, and sitemap, while past posts were still built.

## Limitation

- GitHub Actions schedule is best-effort (minutes of delay; auto-disabled after 60 days of inactivity).
- Date-level only; no time-of-day scheduling and no draft flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented scheduled post publication. Posts with future publication dates are now automatically excluded from the live site and will be published on their scheduled date (evaluated in Asia/Tokyo timezone).

* **Chores**
  * Updated GitHub Pages scheduled deployment timing.

* **Tests**
  * Added test coverage for publication date evaluation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Omochice/blog/pull/1452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->